### PR TITLE
🔧 Use query parameters instead of path parameters

### DIFF
--- a/impressive_strawberry/web/deps/achievement.py
+++ b/impressive_strawberry/web/deps/achievement.py
@@ -15,7 +15,7 @@ __all__ = (
 def dep_achievement(
         session: engine.Session = fastapi.Depends(dep_session),
         group: tables.Group = fastapi.Depends(dep_group),
-        achievement: str = fastapi.Path(...)
+        achievement: str = fastapi.Query(...)
 ):
     try:
         uuid = UUID(achievement)

--- a/impressive_strawberry/web/deps/group.py
+++ b/impressive_strawberry/web/deps/group.py
@@ -15,7 +15,7 @@ __all__ = (
 def dep_group(
         session: engine.Session = fastapi.Depends(dep_session),
         application: tables.Application = fastapi.Depends(dep_application),
-        group: str = fastapi.Path(...)
+        group: str = fastapi.Query(...)
 ):
     try:
         uuid = UUID(group)

--- a/impressive_strawberry/web/deps/user.py
+++ b/impressive_strawberry/web/deps/user.py
@@ -15,7 +15,7 @@ __all__ = (
 def dep_user(
         session: engine.Session = fastapi.Depends(dep_session),
         application: tables.Application = fastapi.Depends(dep_application),
-        user: str = fastapi.Path(...)
+        user: str = fastapi.Query(...)
 ):
     try:
         uuid = UUID(user)

--- a/impressive_strawberry/web/routes/api/achievements/v1/router.py
+++ b/impressive_strawberry/web/routes/api/achievements/v1/router.py
@@ -8,7 +8,7 @@ from impressive_strawberry.web import models
 from impressive_strawberry.web import responses
 
 router = fastapi.routing.APIRouter(
-    prefix="/api/application/v1/this/group/v1/{group}/achievement/v1",
+    prefix="/api/achievement/v1",
     tags=[
         "Achievements v1",
     ],

--- a/impressive_strawberry/web/routes/api/group/v1/router.py
+++ b/impressive_strawberry/web/routes/api/group/v1/router.py
@@ -8,7 +8,7 @@ from impressive_strawberry.web import models
 from impressive_strawberry.web import responses
 
 router = fastapi.routing.APIRouter(
-    prefix="/api/application/v1/this/group/v1",
+    prefix="/api/group/v1",
     tags=[
         "Group v1",
     ],

--- a/impressive_strawberry/web/routes/api/user/v1/router.py
+++ b/impressive_strawberry/web/routes/api/user/v1/router.py
@@ -8,7 +8,7 @@ from impressive_strawberry.web import models
 from impressive_strawberry.web import responses
 
 router = fastapi.routing.APIRouter(
-    prefix="/api/application/v1/this/user/v1",
+    prefix="/api/user/v1",
     tags=[
         "User v1",
     ],


### PR DESCRIPTION
Spostare i parametri dal percorso alla query string accorcia gli URL e permette più facile compatibilità in futuro, rendendo però l'API non-REST.

Ha senso fare questa modifica?