### PR TITLE
✨ Allow requiring a secret to create a new application

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 export IS_DB_URI=
 export IS_WEB_PORT=
+export IS_SECRET=

--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-export IS_DB_URI=
-export IS_WEB_PORT=
-export IS_SECRET=

--- a/.env.testing
+++ b/.env.testing
@@ -1,2 +1,3 @@
 export IS_DB_URI=postgresql://username:password@localhost:5432/db
 export IS_WEB_PORT=30071
+export IS_SECRET=qwerty

--- a/impressive_strawberry/web/deps/__init__.py
+++ b/impressive_strawberry/web/deps/__init__.py
@@ -6,6 +6,7 @@ from .achievement import *
 from .application import *
 from .database import *
 from .group import *
+from .impressive import *
 from .unlock import *
 from .user import *
 
@@ -16,4 +17,5 @@ __all__ = (
     "group",
     "user",
     "unlock",
+    "impressive",
 )

--- a/impressive_strawberry/web/deps/impressive.py
+++ b/impressive_strawberry/web/deps/impressive.py
@@ -1,0 +1,39 @@
+import os
+import re
+
+import fastapi
+from fastapi.security import APIKeyHeader
+
+from impressive_strawberry.database import tables
+from impressive_strawberry.web import errors
+
+__all__ = (
+    "dep_impressive_secret_required",
+)
+
+dep_impressive_secret = APIKeyHeader(
+    scheme_name="impressive_secret",
+    name="Authorization",
+    description="The secret required to perform certain actions on Impressive Strawberry.",
+    auto_error=False,
+)
+
+
+def dep_impressive_secret_required(
+        header: tables.Application = fastapi.Security(dep_impressive_secret),
+) -> None:
+    """
+    Dependency which parses the ``Authorization`` header with the ``Secret XXXXX`` format, raising an error if the secret is invalid or skipping the check completely if the secret is not set.
+    """
+
+    if expected_secret := os.environ.get("IS_SECRET"):
+        if not header:
+            raise errors.MissingAuthHeader()
+
+        if match := re.match(r"^Secret (.+)$", header):
+            secret = match.group(1)
+        else:
+            raise errors.InvalidAuthHeader()
+
+        if secret != expected_secret:
+            raise errors.WrongAuthHeader()

--- a/impressive_strawberry/web/errors/__init__.py
+++ b/impressive_strawberry/web/errors/__init__.py
@@ -50,7 +50,7 @@ class InvalidAuthHeader(StrawberryException):
 class WrongAuthHeader(StrawberryException):
     STATUS_CODE = 401
     ERROR_CODE = "WRONG_AUTH_HEADER"
-    REASON = "The token provideed in the Authorization header does not match any application."
+    REASON = "The value provideed in the Authorization header is in a valid format, but its value is incorrect."
 
 
 class ResourceNotFound(StrawberryException):

--- a/impressive_strawberry/web/routes/api/application/v1/router.py
+++ b/impressive_strawberry/web/routes/api/application/v1/router.py
@@ -26,7 +26,8 @@ router = fastapi.routing.APIRouter(
 async def application_create(
         *,
         data: models.edit.ApplicationEdit,
-        session: Session = fastapi.Depends(deps.dep_dbsession)
+        session: Session = fastapi.Depends(deps.dep_dbsession),
+        _secret: None = fastapi.Depends(deps.dep_impressive_secret_required)
 ):
     return crud.quick_create(session,
                              tables.Application(name=data.name, description=data.description, webhook_url=data.webhook_url, webhook_type=data.webhook_type))

--- a/impressive_strawberry/web/testing/conftest.py
+++ b/impressive_strawberry/web/testing/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import uuid
 
 import dotenv
@@ -156,3 +157,23 @@ def unlock(session: sqlalchemy.orm.Session, user: tables.User, achievement: tabl
         session.commit()
     except sqlalchemy.orm.exc.ObjectDeletedError as e:
         log.warning(f"The row belonging to the object was deleted before teardown.")
+
+
+@pytest.fixture(scope="function")
+def impressive_secret():
+    previous_value = os.environ["IS_SECRET"]
+    new_value = "qwerty"
+
+    os.environ["IS_SECRET"] = new_value
+    yield new_value
+    os.environ["IS_SECRET"] = previous_value
+
+
+@pytest.fixture(scope="function")
+def impressive_secret_unset():
+    previous_value = os.environ["IS_SECRET"]
+    new_value = ""
+
+    os.environ["IS_SECRET"] = new_value
+    yield new_value
+    os.environ["IS_SECRET"] = previous_value

--- a/impressive_strawberry/web/testing/test_application.py
+++ b/impressive_strawberry/web/testing/test_application.py
@@ -25,6 +25,31 @@ class TestApplicationCreate:
         assert data["groups"] == []
         assert data["users"] == []
 
+    async def test_missing_secret(self, client: httpx.AsyncClient):
+        response = await client.post("/api/application/v1/")
+        assert response.status_code == 401
+
+        data = response.json()
+        assert data["error_code"] == "MISSING_AUTH_HEADER"
+
+    async def test_invalid_secret(self, client: httpx.AsyncClient):
+        response = await client.post("/api/application/v1/", headers={
+            "Authorization": "asjduisjfisdjgfiasj",
+        })
+        assert response.status_code == 401
+
+        data = response.json()
+        assert data["error_code"] == "INVALID_AUTH_HEADER"
+
+    async def test_wrong_secret(self, client: httpx.AsyncClient):
+        response = await client.post("/api/application/v1/", headers={
+            "Authorization": "Secret xyzzy",
+        })
+        assert response.status_code == 401
+
+        data = response.json()
+        assert data["error_code"] == "WRONG_AUTH_HEADER"
+
     async def test_missing_body(self, client: httpx.AsyncClient):
         response = await client.post("/api/application/v1/")
         assert response.status_code == 422

--- a/impressive_strawberry/web/testing/test_application.py
+++ b/impressive_strawberry/web/testing/test_application.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.asyncio
 
 
 class TestApplicationCreate:
-    async def test_success(self, client: httpx.AsyncClient):
+    async def test_success_without_secret(self, client: httpx.AsyncClient, impressive_secret_unset: None):
         body = {
             "name": "Closure Industries Bot",
             "description": "A bot for achievements in a warpgate-based game.",
@@ -25,14 +25,34 @@ class TestApplicationCreate:
         assert data["groups"] == []
         assert data["users"] == []
 
-    async def test_missing_secret(self, client: httpx.AsyncClient):
+    async def test_success_with_secret(self, client: httpx.AsyncClient, impressive_secret: str):
+        body = {
+            "name": "Closure Industries Bot",
+            "description": "A bot for achievements in a warpgate-based game.",
+            "webhook_url": "https://example.org/closure",
+            "webhook_type": "STRAWBERRY",
+        }
+
+        response = await client.post("/api/application/v1/", json=body, headers={
+            "Authorization": f"Secret {impressive_secret}"
+        })
+        assert response.status_code == 201
+
+        data = response.json()
+        assert data.items() >= body.items()
+        assert "id" in data
+        assert "token" in data
+        assert data["groups"] == []
+        assert data["users"] == []
+
+    async def test_missing_secret(self, client: httpx.AsyncClient, impressive_secret: str):
         response = await client.post("/api/application/v1/")
         assert response.status_code == 401
 
         data = response.json()
         assert data["error_code"] == "MISSING_AUTH_HEADER"
 
-    async def test_invalid_secret(self, client: httpx.AsyncClient):
+    async def test_invalid_secret(self, client: httpx.AsyncClient, impressive_secret: str):
         response = await client.post("/api/application/v1/", headers={
             "Authorization": "asjduisjfisdjgfiasj",
         })
@@ -41,7 +61,7 @@ class TestApplicationCreate:
         data = response.json()
         assert data["error_code"] == "INVALID_AUTH_HEADER"
 
-    async def test_wrong_secret(self, client: httpx.AsyncClient):
+    async def test_wrong_secret(self, client: httpx.AsyncClient, impressive_secret: str):
         response = await client.post("/api/application/v1/", headers={
             "Authorization": "Secret xyzzy",
         })
@@ -50,11 +70,11 @@ class TestApplicationCreate:
         data = response.json()
         assert data["error_code"] == "WRONG_AUTH_HEADER"
 
-    async def test_missing_body(self, client: httpx.AsyncClient):
+    async def test_missing_body(self, client: httpx.AsyncClient, impressive_secret_unset: None):
         response = await client.post("/api/application/v1/")
         assert response.status_code == 422
 
-    async def test_invalid_body(self, client: httpx.AsyncClient):
+    async def test_invalid_body(self, client: httpx.AsyncClient, impressive_secret_unset: None):
         body = {
             "name": "Failure App",
         }


### PR DESCRIPTION
## Reasoning

Allowing anyone to create an application in Impressive Strawberry might allow a malicious actor to DoS a HTTP server by abusing the webhook feature (#18).

## Changes

A new envvar is introduced, `IS_SECRET`, which, if set, requires a `Authorization` header in the `POST /api/v1/application` route, with the format `Secret <value>`.